### PR TITLE
Make closet-select-mode adjust to night mode

### DIFF
--- a/anki/web/editor.css
+++ b/anki/web/editor.css
@@ -6,4 +6,7 @@ img {
 .closet-select-mode {
   /* sligthly below top */
   vertical-align: 20%;
+  background-color: var(--frame-bg);
+  border-color: var(--border);
+  color: var(--text-fg);
 }

--- a/anki/web/editor.css
+++ b/anki/web/editor.css
@@ -4,8 +4,9 @@ img {
 }
 
 .closet-select-mode {
-  /* sligthly below top */
+  /* slightly below top */
   vertical-align: 20%;
+  /* night-mode fix */
   background-color: var(--frame-bg);
   border-color: var(--border);
   color: var(--text-fg);


### PR DESCRIPTION
![light_vs_dark](https://user-images.githubusercontent.com/62722460/104634659-30992b80-56a1-11eb-9fc4-16fe57369b6b.png)

On Windows, the `<select>` is displayed in a light theme when night mode is on.
Added three lines using Anki's CSS variables to make it night-mode compatible.

The orange border seems to be a Chrome-default value, couldn't find a quick fix for that.