### PR TITLE
2.1.52+ cleanup and fixes

### DIFF
--- a/anki/src/editor/__init__.py
+++ b/anki/src/editor/__init__.py
@@ -4,7 +4,6 @@ import re
 from pathlib import Path
 from os.path import dirname, realpath
 
-from anki.hooks import wrap
 from anki.consts import MODEL_STD, MODEL_CLOZE
 
 from aqt import mw
@@ -170,11 +169,6 @@ def remove_occlusion_code(txt: str, _editor) -> str:
     return txt
 
 
-def turn_of_occlusion_editor_if_in_field(editor, _field):
-    if editor.occlusion_editor_active:
-        editor.web.eval("EditorCloset.clearOcclusionMode()")
-
-
 def on_cloze(editor) -> None:
     model = editor.note.model()
 
@@ -210,7 +204,3 @@ def init_editor():
     editor_did_init_shortcuts.append(add_occlusion_shortcut)
 
     editor_will_munge_html.append(remove_occlusion_code)
-
-    Editor._onHtmlEdit = wrap(
-        Editor._onHtmlEdit, turn_of_occlusion_editor_if_in_field, "before"
-    )

--- a/anki/src/editor/__init__.py
+++ b/anki/src/editor/__init__.py
@@ -160,7 +160,8 @@ def add_occlusion_shortcut(cuts, editor):
 
 
 occlusion_container_pattern = re.compile(
-    r'<div class="closet-occlusion-container">(<img.*?>).*?</div>'
+    # remove trailing <br> to prevent accumulation
+    r'<div class="closet-occlusion-container">.*?(<img.*?>).*?</div>(<br>)*'
 )
 
 

--- a/anki/src/editor/__init__.py
+++ b/anki/src/editor/__init__.py
@@ -66,6 +66,9 @@ def toggle_occlusion_mode(editor):
     escaped_version = escape_js_text(closet_version_per_model.value)
     max_code_fields = get_max_code_field(editor)
 
+    if not mw.focusWidget() is editor:
+        refocus(editor)
+
     editor.web.eval(
         f'EditorCloset.toggleOcclusionMode("{escaped_version}", {max_code_fields})'
     )
@@ -206,13 +209,16 @@ def clear_occlusion_mode(js, note, editor):
 
 def refocus(editor):
     editor.web.setFocus()
-    editor.web.eval("EditorCloset.refocusField(); ")
+    editor.web.eval("EditorCloset.refocus(); ")
+
+
+def maybe_refocus(editor):
+    editor.web.eval("EditorCloset.maybeRefocus(); ")
 
 
 def init_editor():
     editor_did_init_buttons.append(add_buttons)
     editor_did_init_shortcuts.append(add_occlusion_shortcut)
     editor_will_load_note.append(clear_occlusion_mode)
-    editor_did_load_note.append(refocus)
-
+    editor_did_load_note.append(maybe_refocus)
     editor_will_munge_html.append(remove_occlusion_code)

--- a/anki/src/editor/__init__.py
+++ b/anki/src/editor/__init__.py
@@ -13,6 +13,7 @@ from aqt.gui_hooks import (
     editor_did_init_buttons,
     editor_did_init_shortcuts,
     editor_did_load_note,
+    editor_will_load_note,
     editor_will_munge_html,
 )
 from aqt.utils import shortcut, showInfo
@@ -199,8 +200,19 @@ def on_cloze(editor) -> None:
     editor.web.eval(f'wrap("{prefix}", "{suffix}");')
 
 
+def clear_occlusion_mode(js, note, editor):
+    return f"EditorCloset.clearOcclusionMode().then(() => {{ {js} }}); "
+
+
+def refocus(editor):
+    editor.web.setFocus()
+    editor.web.eval("EditorCloset.refocusField(); ")
+
+
 def init_editor():
     editor_did_init_buttons.append(add_buttons)
     editor_did_init_shortcuts.append(add_occlusion_shortcut)
+    editor_will_load_note.append(clear_occlusion_mode)
+    editor_did_load_note.append(refocus)
 
     editor_will_munge_html.append(remove_occlusion_code)

--- a/anki/src/webview/__init__.py
+++ b/anki/src/webview/__init__.py
@@ -9,7 +9,7 @@ from aqt.gui_hooks import (
 )
 from aqt.utils import showInfo
 
-from ..editor.__init__ import on_cloze
+from ..editor.__init__ import on_cloze, refocus
 from ..utils import (
     closet_enabled,
     closet_version_per_model,
@@ -88,6 +88,10 @@ def add_occlusion_messages(handled: bool, message: str, context) -> Tuple[bool, 
 
         elif message.startswith("closetCloze"):
             on_cloze(editor)
+            return (True, None)
+
+        elif message.startswith("closetRefocus"):
+            refocus(editor)
             return (True, None)
 
     return handled

--- a/anki/src/webview/__init__.py
+++ b/anki/src/webview/__init__.py
@@ -94,6 +94,12 @@ def add_occlusion_messages(handled: bool, message: str, context) -> Tuple[bool, 
             refocus(editor)
             return (True, None)
 
+        elif message.startswith("closetMultipleImages"):
+            showInfo(
+                "Cannot start occlusion editor if field contains multiple images."
+            )
+            return (True, None)
+
     return handled
 
 

--- a/anki/web/editor.js
+++ b/anki/web/editor.js
@@ -263,10 +263,16 @@ var EditorCloset = {
         }
     },
 
-    refocusField: () => {
+    maybeRefocus: () => {
         if (EditorCloset.hadOcclusionEditor) {
-            EditorCloset.occlusionField.editingArea.refocus();
+            bridgeCommand("closetRefocus");
             EditorCloset.hadOcclusionEditor = false;
+        }
+    },
+
+    refocus: () => {
+        if (EditorCloset.occlusionField) {
+            EditorCloset.occlusionField.editingArea.refocus();
         }
     },
 

--- a/anki/web/editor.js
+++ b/anki/web/editor.js
@@ -6,17 +6,15 @@ var rushInOut = (x) => {
 /** Python functions moved to JS for async operations **/
 var escapeJSText = (text) => {
     return text.replace("\\", "\\\\").replace('"', '\\"').replace("'", "\\'");
-}
+};
 
 var getFocusedFieldIndex = () => {
     if (document.activeElement.classList.contains("rich-text-editable")) {
-        return [...document.querySelector(".fields").children]
-        .indexOf(
+        return [...document.querySelector(".fields").children].indexOf(
             document.activeElement.closest(".editor-field").parentNode
-        )
-    }
-    else return 0;
-}
+        );
+    } else return 0;
+};
 
 var replaceOrPrefixOldOcclusionText = (oldHTML, newText) => {
     const occlusionBlockRegex = /\[#!occlusions.*?#\]/;
@@ -29,18 +27,18 @@ var replaceOrPrefixOldOcclusionText = (oldHTML, newText) => {
         const subbed = oldHTML.replace(occlusionBlockRegex, () => {
             ++count;
             return replacement;
-        })
+        });
         return [subbed, count];
     })();
-    
+
     if (numberOfSubs > 0) {
         return subbed;
     } else if (["", "<br>"].includes(oldHTML)) {
         return replacement;
     } else {
         return `${replacement}<br>${oldHTML}`;
-    } 
-}
+    }
+};
 
 const NoteEditor = require("anki/NoteEditor");
 const EditorField = require("anki/EditorField");
@@ -70,7 +68,7 @@ img {
 .closet-rect__label {
   stroke: black;
   stroke-width: 0.5;
-}`
+}`;
 
 /** Cloze support for non-cloze notetypes on 2.1.50+ **/
 document.addEventListener("keydown", (evt) => {
@@ -80,19 +78,19 @@ document.addEventListener("keydown", (evt) => {
 });
 
 EditorField.lifecycle.onMount((field) => {
-    (async() => {
+    (async () => {
         const fieldElement = await field.element;
 
         if (!fieldElement.hasAttribute("has-occlusion-style")) {
             const style = document.createElement("style");
-            style.id = "closet-occlusion-style"
+            style.id = "closet-occlusion-style";
             style.rel = "stylesheet";
             style.textContent = occlusionCss;
-            const richTextEditable = await get(field.editingArea.editingInputs)
-                .find((input) => input.name === "rich-text")
-                .element;
+            const richTextEditable = await get(
+                field.editingArea.editingInputs
+            ).find((input) => input.name === "rich-text").element;
             richTextEditable.getRootNode().prepend(style);
-    
+
             fieldElement.setAttribute("has-occlusion-style", "");
         }
     })();
@@ -122,7 +120,7 @@ var EditorCloset = {
     },
 
     getFieldHTML: async (index) => {
-        const richTextEditable = await EditorCloset.getRichTextEditable(index)
+        const richTextEditable = await EditorCloset.getRichTextEditable(index);
         return richTextEditable.innerHTML;
     },
 
@@ -132,9 +130,9 @@ var EditorCloset = {
     },
 
     getRichTextEditable: async (index) => {
-        return await get(NoteEditor.instances[0].fields[index].editingArea.editingInputs)
-        .find((input) => input.name === "rich-text")
-        .element;
+        return await get(
+            NoteEditor.instances[0].fields[index].editingArea.editingInputs
+        ).find((input) => input.name === "rich-text").element;
     },
 
     setupOcclusionEditor: async (closet, maxOcclusions) => {
@@ -167,10 +165,9 @@ var EditorCloset = {
             elements.push(richTextEditable);
         }
 
-
         const acceptHandler = (_entry, internals) => (shapes, draw) => {
             const imageSrc = draw.image.src.match(
-                EditorCloset.imageSrcPattern,
+                EditorCloset.imageSrcPattern
             )[1];
 
             const newIndices = [
@@ -178,11 +175,11 @@ var EditorCloset = {
                     shapes
                         .map((shape) => shape.labelText)
                         .map((label) =>
-                            label.match(closet.patterns.keySeparation),
+                            label.match(closet.patterns.keySeparation)
                         )
                         .filter((match) => match)
                         .map((match) => Number(match[2]))
-                        .filter((maybeNumber) => !Number.isNaN(maybeNumber)),
+                        .filter((maybeNumber) => !Number.isNaN(maybeNumber))
                 ),
             ];
 
@@ -190,7 +187,7 @@ var EditorCloset = {
 
             const shapeText = shapes
                 .map((shape) =>
-                    shape.toText(internals.template.parser.delimiters),
+                    shape.toText(internals.template.parser.delimiters)
                 )
                 .join("\n");
 
@@ -220,16 +217,16 @@ var EditorCloset = {
                     shapeDefs
                         .map((shape) => shape[2])
                         .map((label) =>
-                            label.match(closet.patterns.keySeparation),
+                            label.match(closet.patterns.keySeparation)
                         )
                         .filter((match) => match)
                         .map((match) => Number(match[2]))
-                        .filter((maybeNumber) => !Number.isNaN(maybeNumber)),
+                        .filter((maybeNumber) => !Number.isNaN(maybeNumber))
                 ),
             ];
 
             const imageSrc = draw.image.src.match(
-                EditorCloset.imageSrcPattern,
+                EditorCloset.imageSrcPattern
             )[1];
             bridgeCommand(`oldOcclusions:${imageSrc}:${indices.join(",")}`);
 
@@ -248,12 +245,12 @@ var EditorCloset = {
 
         filterManager.install(
             ...["rect", "recth", "rectr"].map((tagname) =>
-                closet.browser.recipes.rect.hide({ tagname }),
-            ),
+                closet.browser.recipes.rect.hide({ tagname })
+            )
         );
 
         closet.template.BrowserTemplate.makeFromNodes(elements).render(
-            filterManager,
+            filterManager
         );
 
         EditorCloset.setActive(target);
@@ -261,8 +258,9 @@ var EditorCloset = {
 
     clearOcclusionMode: async () => {
         if (EditorCloset.occlusionMode) {
-
-            EditorCloset.occlusionEditorTarget.dispatchEvent(new Event("reject"));
+            EditorCloset.occlusionEditorTarget.dispatchEvent(
+                new Event("reject")
+            );
 
             EditorCloset.occlusionField.callback.call();
             EditorCloset.focusIndex = getFocusedFieldIndex();
@@ -294,9 +292,9 @@ var EditorCloset = {
                 (closet) =>
                     EditorCloset.setupOcclusionEditor(
                         closet.closet,
-                        maxOcclusions,
+                        maxOcclusions
                     ),
-                (error) => console.log("Could not load Closet:", error),
+                (error) => console.log("Could not load Closet:", error)
             );
         }
     },
@@ -333,7 +331,7 @@ var EditorCloset = {
     setMaxHeight: (value /* > 0 */) => {
         document.documentElement.style.setProperty(
             "--closet-max-height",
-            `${value}px`,
+            `${value}px`
         );
     },
 };

--- a/anki/web/editor.js
+++ b/anki/web/editor.js
@@ -4,31 +4,32 @@ var rushInOut = (x) => {
 };
 
 /** Python functions moved to JS for async operations **/
-var escape_js_text = (text) => {
+var escapeJSText = (text) => {
     return text.replace("\\", "\\\\").replace('"', '\\"').replace("'", "\\'");
 }
 
-var replace_or_prefix_old_occlusion_text = (old_html, new_text) => {
-    const occlusion_block_regex = /\[#!occlusions.*?#\]/;
 
-    const new_html = new_text.split(/\r?\n/).join("<br>");
-    replacement = `[#!occlusions ${new_html} #]`;
+var replaceOrPrefixOldOcclusionText = (oldHTML, newText) => {
+    const occlusionBlockRegex = /\[#!occlusions.*?#\]/;
+
+    const newHTML = newText.split(/\r?\n/).join("<br>");
+    replacement = `[#!occlusions ${newHTML} #]`;
 
     /** imitate re.subn **/
-    [subbed, number_of_subs] = ((count = 0) => {
-        const subbed = old_html.replace(occlusion_block_regex, () => {
+    [subbed, numberOfSubs] = ((count = 0) => {
+        const subbed = oldHTML.replace(occlusionBlockRegex, () => {
             ++count;
             return replacement;
         })
         return [subbed, count];
     })();
     
-    if (number_of_subs > 0) {
+    if (numberOfSubs > 0) {
         return subbed;
-    } else if (["", "<br>"].includes(old_html)) {
+    } else if (["", "<br>"].includes(oldHTML)) {
         return replacement;
     } else {
-        return `${replacement}<br>${old_html}`;
+        return `${replacement}<br>${oldHTML}`;
     } 
 }
 
@@ -275,11 +276,11 @@ var EditorCloset = {
         }
     },
 
-    insertIntoZeroIndexed: async (new_text, index) => {
-        const old_html = await EditorCloset.getFieldHTML(index);
-        const text = replace_or_prefix_old_occlusion_text(old_html, new_text);
+    insertIntoZeroIndexed: async (newText, index) => {
+        const oldHTML = await EditorCloset.getFieldHTML(index);
+        const text = replaceOrPrefixOldOcclusionText(oldHTML, newText);
 
-        const escaped = escape_js_text(text);
+        const escaped = escapeJSText(text);
 
         pycmd(`key:${index}:${getNoteId()}:${escaped}`);
         EditorCloset.setFieldHTML(index, escaped);

--- a/anki/web/editor.js
+++ b/anki/web/editor.js
@@ -139,21 +139,30 @@ var EditorCloset = {
 
     setupOcclusionEditor: async (closet, maxOcclusions) => {
         const elements = ["[[makeOcclusions]]"];
+        let fieldFound = false;
 
         for (const field of NoteEditor.instances[0].fields) {
-            const richTextInputAPI = get(field.editingArea.editingInputs)
-                .find((input) => input.name === "rich-text");
-            
+            const richTextInputAPI = get(field.editingArea.editingInputs).find(
+                (input) => input.name === "rich-text"
+            );
+
             const richTextEditable = await richTextInputAPI.element;
-            if (
-                richTextEditable.querySelector("img")
-                && !EditorCloset.occlusionField
-            ) {
-                EditorCloset.occlusionField = {
-                    editingArea: field.editingArea,
-                    callback: richTextInputAPI.preventResubscription(),
-                };
-                field.editingArea.refocus();
+
+            if (!fieldFound) {
+                let images = richTextEditable.querySelectorAll("img");
+
+                if (images.length && !fieldFound) {
+                    if (images.length > 1) {
+                        bridgeCommand("closetMultipleImages");
+                        return;
+                    }
+                    EditorCloset.occlusionField = {
+                        editingArea: field.editingArea,
+                        callback: richTextInputAPI.preventResubscription(),
+                    };
+                    fieldFound = true;
+                    field.editingArea.refocus();
+                }
             }
             elements.push(richTextEditable);
         }

--- a/anki/web/editor.js
+++ b/anki/web/editor.js
@@ -69,22 +69,24 @@ document.addEventListener("keydown", (evt) => {
     }
 });
 
-EditorField.lifecycle.onMount(async (field) => {
-    const fieldElement = await field.element;
+EditorField.lifecycle.onMount((field) => {
+    (async() => {
+        const fieldElement = await field.element;
 
-    if (!fieldElement.hasAttribute("has-occlusion-style")) {
-        const style = document.createElement("style");
-        style.id = "closet-occlusion-style"
-        style.rel = "stylesheet";
-        style.textContent = occlusionCss;
-        const richTextEditable = await get(field.editingArea.editingInputs)
-            .find((input) => input.name === "rich-text")
-            .element;
-        richTextEditable.getRootNode().prepend(style);
-
-        fieldElement.setAttribute("has-occlusion-style", "");
-    }
-})
+        if (!fieldElement.hasAttribute("has-occlusion-style")) {
+            const style = document.createElement("style");
+            style.id = "closet-occlusion-style"
+            style.rel = "stylesheet";
+            style.textContent = occlusionCss;
+            const richTextEditable = await get(field.editingArea.editingInputs)
+                .find((input) => input.name === "rich-text")
+                .element;
+            richTextEditable.getRootNode().prepend(style);
+    
+            fieldElement.setAttribute("has-occlusion-style", "");
+        }
+    })();
+});
 
 var EditorCloset = {
     imageSrcPattern: /^https?:\/\/(?:localhost|127.0.0.1):\d+\/(.*)$/u,


### PR DESCRIPTION
Closes #96
and a bit of cleanup.

#95 suffered from two major issues:
1. https://github.com/ankitects/anki/issues/1980 - My PR had assumed a correct order. Switching to notetypes with differing # of fields would therefore cause Closet to insert occlusion code at wrong indices. The `fields` of `NoteEditor` API are ordered correctly.

2. Fields don't automatically update their state when Closet changes field contents. This could result in images getting copied to different notes' fields. I experimented a lot and settled on handling focus (forcing state updates) when loading notes.

## Caveat: Multiple Images
The way I fixed issue 2 doesn't allow for multiple images on a single IO note. In my eyes, the best approach would be to enable the IO editor only on the first image of the note. Another idea that came to mind was to hook into Anki's image handle (i.e. add the IO button there). Then users could easily decide which image should get the occlusions.