### PR TITLE
Fix DOMException triggered by .removeChild() in specific situations

### DIFF
--- a/src/template/browser/childNodes.ts
+++ b/src/template/browser/childNodes.ts
@@ -265,7 +265,9 @@ export class ChildNodeSpan {
             this.parentElement.childNodes[this._fromIndex],
         );
         for (const node of this.span()) {
-            this.parentElement.removeChild(node);
+            if(node.parentElement === this.parentElement) {
+                this.parentElement.removeChild(node);
+            }
         }
 
         // might turn the original div into multiple nodes including text nodes


### PR DESCRIPTION
We've been investigating an issue with the AnKing IO one by one note type: https://github.com/AnKing-VIP/AnKing-Note-Types/issues/158

I found the issue only appears in some very specific situations, such that when another add-on injects scripts into the reviewer webview using gui_hooks.card_will_show and there is some random whitespace in the template... It's a super weird issue - probably some kind of a race condition. This is a quick and dirty solution.

## Reproduction steps

- Import the sample deck in https://github.com/AnKing-VIP/AnKing-Note-Types/issues/158
- Install this sample add-on, which simply injects a script using gui_hooks.card_will_show: [test_addon.zip](https://github.com/hgiesel/closet/files/13527060/test_addon.zip)
- You should notice the masks no longer appear.
- Now we got to the weird part: if you remove some specific lines in template as shown in the screenshots, the issue disappears:

### Before

![image](https://github.com/hgiesel/closet/assets/41397710/81dcbc2d-7b5f-46c8-a702-b644dbb205f4)

### After
![image](https://github.com/hgiesel/closet/assets/41397710/9a4b7a7c-99cc-4bfd-9988-a07a5acc10aa)
